### PR TITLE
refactor: title과 stock사이에 priority설정함으로써 ambiguous layout 제거

### DIFF
--- a/ShoppersClub/View/ListTableViewCell.swift
+++ b/ShoppersClub/View/ListTableViewCell.swift
@@ -33,7 +33,8 @@ class ListTableViewCell: UITableViewCell {
         itemTitleLabel.translatesAutoresizingMaskIntoConstraints = false
         itemTitleLabel.font = UIFont.preferredFont(forTextStyle: .title2)
         itemTitleLabel.textColor = .black
-        itemTitleLabel.numberOfLines = 0
+        itemTitleLabel.numberOfLines = 2
+        itemTitleLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         return itemTitleLabel
     }()
     let itemStockLabel: UILabel = {
@@ -41,6 +42,8 @@ class ListTableViewCell: UITableViewCell {
         itemStockLabel.translatesAutoresizingMaskIntoConstraints = false
         itemStockLabel.font = UIFont.preferredFont(forTextStyle: .body)
         itemStockLabel.textColor = .gray
+        itemStockLabel.textAlignment = .right
+        itemStockLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
         return itemStockLabel
     }()
     let itemPriceLabel: UILabel = {
@@ -74,7 +77,7 @@ class ListTableViewCell: UITableViewCell {
             itemStockLabel.text = "품절"
             itemStockLabel.textColor = .orange
         } else {
-            itemStockLabel.text = "재고: \(String(item.stock))"
+            itemStockLabel.text = "잔여 수량: \(String(item.stock))"
         }
         itemPriceLabel.text = "\(item.currency) \(String(item.price))"
         if let itemDiscountedPrice = item.discountedPrice {


### PR DESCRIPTION
- title과 stock이 cell의 width보다 길어져 공간이 부족할 경우 title이 잘리게 함으로 priority 설정
---
유저입장에서 title은 thumbnailsImage를 보고 대략적으로 유추할 수 있기도 하고 상세화면에서 full name을 확인할 수 있음.
재고는 상세화면에 굳이 들어가지 않고 Item의 List를 보면서 비교할 수 있어야 한다고 판단하여 title의 priority를 defalutLow로 설정