### PR TITLE
Feature/network get

### DIFF
--- a/ShoppersClub.xcodeproj/project.pbxproj
+++ b/ShoppersClub.xcodeproj/project.pbxproj
@@ -9,7 +9,6 @@
 /* Begin PBXBuildFile section */
 		451B6ED4273F89EB00BB897D /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 451B6ED3273F89EB00BB897D /* AppDelegate.swift */; };
 		451B6ED6273F89EB00BB897D /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 451B6ED5273F89EB00BB897D /* SceneDelegate.swift */; };
-		451B6ED8273F89EB00BB897D /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 451B6ED7273F89EB00BB897D /* ViewController.swift */; };
 		451B6EDD273F89EC00BB897D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 451B6EDC273F89EC00BB897D /* Assets.xcassets */; };
 		451B6EE0273F89EC00BB897D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 451B6EDE273F89EC00BB897D /* LaunchScreen.storyboard */; };
 		45391A13274CD925006F2B7A /* ListTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45391A12274CD925006F2B7A /* ListTableViewCell.swift */; };
@@ -20,13 +19,15 @@
 		4577F8E6273F9A5600004AE2 /* ItemRegistration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4577F8E5273F9A5600004AE2 /* ItemRegistration.swift */; };
 		4577F8E8273F9AC200004AE2 /* ItemModification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4577F8E7273F9AC200004AE2 /* ItemModification.swift */; };
 		4577F8EA273F9AEF00004AE2 /* ItemDelete.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4577F8E9273F9AEF00004AE2 /* ItemDelete.swift */; };
+		458874FE275DEF7E00BE331E /* NetworkItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 458874FD275DEF7E00BE331E /* NetworkItem.swift */; };
+		45887500275DEF8C00BE331E /* ShoppersClubAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 458874FF275DEF8C00BE331E /* ShoppersClubAPI.swift */; };
+		45887502275DF00100BE331E /* MainListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45887501275DF00100BE331E /* MainListViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		451B6ED0273F89EB00BB897D /* ShoppersClub.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ShoppersClub.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		451B6ED3273F89EB00BB897D /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		451B6ED5273F89EB00BB897D /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
-		451B6ED7273F89EB00BB897D /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
 		451B6EDC273F89EC00BB897D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		451B6EDF273F89EC00BB897D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		451B6EE1273F89EC00BB897D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -38,6 +39,9 @@
 		4577F8E5273F9A5600004AE2 /* ItemRegistration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemRegistration.swift; sourceTree = "<group>"; };
 		4577F8E7273F9AC200004AE2 /* ItemModification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemModification.swift; sourceTree = "<group>"; };
 		4577F8E9273F9AEF00004AE2 /* ItemDelete.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemDelete.swift; sourceTree = "<group>"; };
+		458874FD275DEF7E00BE331E /* NetworkItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = NetworkItem.swift; path = ../../../../../iOS/ShoppersClub/ShoppersClub/Model/Network/NetworkItem.swift; sourceTree = "<group>"; };
+		458874FF275DEF8C00BE331E /* ShoppersClubAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ShoppersClubAPI.swift; path = ../../../../../iOS/ShoppersClub/ShoppersClub/Model/Network/ShoppersClubAPI.swift; sourceTree = "<group>"; };
+		45887501275DF00100BE331E /* MainListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MainListViewController.swift; path = ../../../../iOS/ShoppersClub/ShoppersClub/View/MainListViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -84,7 +88,7 @@
 		45391A11274CD90E006F2B7A /* View */ = {
 			isa = PBXGroup;
 			children = (
-				451B6ED7273F89EB00BB897D /* ViewController.swift */,
+				45887501275DF00100BE331E /* MainListViewController.swift */,
 				45391A12274CD925006F2B7A /* ListTableViewCell.swift */,
 			);
 			path = View;
@@ -94,7 +98,9 @@
 			isa = PBXGroup;
 			children = (
 				45414263274904220008EB87 /* NetworkError.swift */,
+				458874FF275DEF8C00BE331E /* ShoppersClubAPI.swift */,
 				454142612748FABF0008EB87 /* NetworkManager.swift */,
+				458874FD275DEF7E00BE331E /* NetworkItem.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -198,12 +204,14 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				45887500275DEF8C00BE331E /* ShoppersClubAPI.swift in Sources */,
+				45887502275DF00100BE331E /* MainListViewController.swift in Sources */,
 				45391A13274CD925006F2B7A /* ListTableViewCell.swift in Sources */,
 				454142622748FABF0008EB87 /* NetworkManager.swift in Sources */,
 				4577F8D6273F92A500004AE2 /* Item.swift in Sources */,
+				458874FE275DEF7E00BE331E /* NetworkItem.swift in Sources */,
 				4577F8D4273F92A000004AE2 /* ItemList.swift in Sources */,
 				4577F8E6273F9A5600004AE2 /* ItemRegistration.swift in Sources */,
-				451B6ED8273F89EB00BB897D /* ViewController.swift in Sources */,
 				451B6ED4273F89EB00BB897D /* AppDelegate.swift in Sources */,
 				4577F8EA273F9AEF00004AE2 /* ItemDelete.swift in Sources */,
 				4577F8E8273F9AC200004AE2 /* ItemModification.swift in Sources */,

--- a/ShoppersClub/Model/Network/NetworkError.swift
+++ b/ShoppersClub/Model/Network/NetworkError.swift
@@ -14,4 +14,21 @@ enum NetworkError: Error {
     case invalidHttpStatusCode
     case emptyData
     case decodingError
+    
+    var errorDescription: String? {
+        switch self {
+        case .unknownError:
+            return "An unknown error has occurred!"
+        case .invalidURL:
+            return "URL is invalid!"
+        case .invalidResponse:
+            return "HTTPResponse is invalid!"
+        case .invalidHttpStatusCode:
+            return "HTTPStatusCode does not match!"
+        case .emptyData:
+            return "Data is empty!"
+        case .decodingError:
+            return "An error occurred during decoding!"
+        }
+    }
 }

--- a/ShoppersClub/Model/Network/NetworkItem.swift
+++ b/ShoppersClub/Model/Network/NetworkItem.swift
@@ -1,0 +1,39 @@
+//
+//  NetworkItem.swift
+//  ShoppersClub
+//
+//  Created by 오인탁 on 2021/12/06.
+//
+
+import Foundation
+
+class NetworkItem {
+    let networkManager = NetworkManager()
+    
+    func fetchItems(request: URLRequest, completion: @escaping (Result<ItemList, Error>) -> Void) {
+        networkManager.fetchData(request: request) { result in
+            switch result {
+            case .success(let data):
+                guard let decoding = self.decodeItems(data: data) else {
+                    completion(.failure(NetworkError.decodingError))
+                    return
+                }
+                completion(.success(decoding))
+            case .failure(_):
+                completion(.failure(NetworkError.emptyData))
+            }
+        }
+    }
+    
+    func decodeItems(data: Data) -> ItemList? {
+        guard let itemData = try? JSONDecoder().decode(ItemList.self, from: data) else { return nil }
+        return itemData
+    }
+    
+    /// GET - 목록 조회
+    func loadItemListRequest(page: UInt) -> URLRequest {
+        let requestURL = ShoppersClubAPI.loadItemList(page: page).url
+        let request = URLRequest(url: requestURL)
+        return request
+    }
+}

--- a/ShoppersClub/Model/Network/NetworkManager.swift
+++ b/ShoppersClub/Model/Network/NetworkManager.swift
@@ -14,8 +14,8 @@ struct NetworkManager {
         self.session = session
     }
     
-    func fetchData(url: URL, completion: @escaping (Result<Data, Error>) -> Void) {
-        let task = URLSession.shared.dataTask(with: url) { data, response, error in
+    func fetchData(request: URLRequest, completion: @escaping (Result<Data, Error>) -> Void) {
+        let task = session.dataTask(with: request) { data, response, error in
             if error != nil {
                 completion(.failure(NetworkError.unknownError))
                 return

--- a/ShoppersClub/Model/Network/ShoppersClubAPI.swift
+++ b/ShoppersClub/Model/Network/ShoppersClubAPI.swift
@@ -1,0 +1,47 @@
+//
+//  ShoppersClubAPI.swift
+//  ShoppersClub
+//
+//  Created by 오인탁 on 2021/12/06.
+//
+
+import Foundation
+
+enum ShoppersClubAPI {
+    static let baseURL = "https://camp-open-market-2.herokuapp.com/"
+    case loadItemList(page: UInt)
+    case loadItem(id: UInt)
+    case registrateItem
+    case editItem(id: UInt)
+    case deleteItem(id: UInt)
+    
+    var url: URL {
+        switch self {
+        case .loadItemList(let page):
+            return URL(string: ShoppersClubAPI.baseURL + "/items/" + "\(page)")!
+        case .loadItem(let id):
+            return URL(string: ShoppersClubAPI.baseURL + "/item/" + "\(id)")!
+        case .registrateItem:
+            return URL(string: ShoppersClubAPI.baseURL + "/item")!
+        case .editItem(let id):
+            return URL(string: ShoppersClubAPI.baseURL + "/items/" + "\(id)")!
+        case .deleteItem(let id):
+            return URL(string: ShoppersClubAPI.baseURL + "/item/" + "\(id)")!
+        }
+    }
+    
+    var method: String {
+        switch self {
+        case .loadItemList:
+            return "GET"
+        case .loadItem:
+            return "GET"
+        case .registrateItem:
+            return "POST"
+        case .editItem:
+            return "PATCH"
+        case .deleteItem:
+            return "DELETE"
+        }
+    }
+}

--- a/ShoppersClub/SceneDelegate.swift
+++ b/ShoppersClub/SceneDelegate.swift
@@ -18,7 +18,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
-        let mainViewController = ViewController()
+        let mainViewController = MainListViewController()
         let navigationController = UINavigationController(rootViewController: mainViewController)
         window?.rootViewController = navigationController
         window?.makeKeyAndVisible()

--- a/ShoppersClub/View/ListTableViewCell.swift
+++ b/ShoppersClub/View/ListTableViewCell.swift
@@ -90,7 +90,8 @@ class ListTableViewCell: UITableViewCell {
     
     private func configureThumbnails(with path: String) {
         let url = URL(string: path)!
-        networkManager.fetchData(url: url) { [weak self] result in
+        let request = URLRequest(url: url)
+        networkManager.fetchData(request: request) { [weak self] result in
             switch result {
             case .success(let data):
                 let image = UIImage(data: data)!

--- a/ShoppersClub/View/MainListViewController.swift
+++ b/ShoppersClub/View/MainListViewController.swift
@@ -1,0 +1,70 @@
+//
+//  MainListViewController.swift
+//  ShoppersClub
+//
+//  Created by 오인탁 on 2021/12/06.
+//
+
+import UIKit
+
+class MainListViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
+
+    var items: [Item] = []
+    let networkManager = NetworkManager()
+    let networkItem = NetworkItem()
+    let listTableView: UITableView = {
+        let ListTableView = UITableView()
+        ListTableView.register(ListTableViewCell.self, forCellReuseIdentifier: ListTableViewCell.cellId)
+        ListTableView.translatesAutoresizingMaskIntoConstraints = false
+        return ListTableView
+    }()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .white
+        listTableView.delegate = self
+        listTableView.dataSource = self
+        listTableViewConstraints()
+        fetchGetItems(page: 1)
+    }
+    
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return items.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: ListTableViewCell.cellId, for: indexPath) as? ListTableViewCell else { return UITableViewCell() }
+        cell.configureCell(with: items[indexPath.row])
+        cell.prepareForReuse()
+        return cell
+    }
+    
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return 100
+    }
+    
+    func listTableViewConstraints() {
+        view.addSubview(listTableView)
+        NSLayoutConstraint.activate([
+            listTableView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            listTableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            listTableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            listTableView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+        ])
+    }
+    
+    func fetchGetItems(page: UInt) {
+        let request = networkItem.loadItemListRequest(page: page)
+        networkItem.fetchItems(request: request) { result in
+            switch result {
+            case .success(let itemList):
+                DispatchQueue.main.async {
+                    self.items.append(contentsOf: itemList.items)
+                    self.listTableView.reloadData()
+                }
+            case .failure(_):
+                fatalError()
+            }
+        }
+    }
+}


### PR DESCRIPTION
## refactoring을 위한 Model타입(Network) 생성
### ShoppersClubAPI 타입 생성
- 하드코딩 제거 및 오타 방지
### NetworkItem 타입 생성
- ShoppersClubAPI타입의 case들을 이용하여 각 Networking작업을 위한 URLRequest를 반환하는 메서드 생성
### MainViewController의 fetchItems 수정
- 하드코딩 제거


## trouble shooting
커밋하나를 잘못해서 다시 되돌리려고 `git reset --hard HEAD^` 를 사용했다가 파일이 날라감.
git reflog 로 해당 커밋ID를 알아내서 HEAD시점을 다시 되돌려봤지만 이미 날아간 파일은 복구가 불가능했음.

프로젝트에 필요한 기술을 익히기 위해 사이드프로젝트에 옮겨 담았던 코드를 가져와 리팩토링해 파일을 다시 생성.

> ### 교훈
> - 커밋은 제때제때 하자.
> - 커밋을 되돌릴 일이 있으면 `--hard`는 지양하도록 하자. (`--soft`라는 좋은 방법이 있음.)
