### PR TITLE
feat: tableView Infinite Scroll 구현

### DIFF
--- a/ShoppersClub/View/MainListViewController.swift
+++ b/ShoppersClub/View/MainListViewController.swift
@@ -10,6 +10,7 @@ import UIKit
 class MainListViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
 
     var items: [Item] = []
+    var page: UInt = 1
     let networkManager = NetworkManager()
     let networkItem = NetworkItem()
     let listTableView: UITableView = {
@@ -24,6 +25,7 @@ class MainListViewController: UIViewController, UITableViewDelegate, UITableView
         view.backgroundColor = .white
         listTableView.delegate = self
         listTableView.dataSource = self
+        listTableView.prefetchDataSource = self
         listTableViewConstraints()
         fetchGetItems(page: 1)
     }
@@ -67,4 +69,25 @@ class MainListViewController: UIViewController, UITableViewDelegate, UITableView
             }
         }
     }
+}
+
+extension MainListViewController: UITableViewDataSourcePrefetching {
+/// infinity Scoll other way
+//    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+//        let contentYOffset: CGFloat = scrollView.contentOffset.y
+//
+//        if (scrollView.contentSize.height - scrollView.frame.height) < contentYOffset {
+//            fetchGetItems(page: page)
+//            page += 1
+//        }
+//    }
+    func tableView(_ tableView: UITableView, prefetchRowsAt indexPaths: [IndexPath]) {
+        for indexPath in indexPaths {
+            if  items.count == indexPath.row + 2 {
+                self.page += 1
+                fetchGetItems(page: page)
+            }
+        }
+    }
+    
 }


### PR DESCRIPTION
- default값을 1로 갖는 UInt타입의 `page` 프로퍼티 생성
- tableView.prefetchRowsAt 메서드 사용(UITableViewDataSourcePrefetching 프로토콜 채택) -> 서버 통신과 같은 비동기 상황에서 가장 자연스러운 pagination 방법(용량이 큰 데이터나, 퍼포먼스에 부담이 될 수 있는 작업에 효과적)
- items배열의 count와 indexPath+2가 같아지는 시점에 page에 1을 더해주고 fetchGetItems메서드를 호출하는 반복문 생성


### Infinite Scroll을 구현하는 다른 방법
1. scrollViewDidScroll 메서드 구현
 - scrollView의 (contentSize-heightFrame)보다 contentOffset.y 가 클 경우 page에 1을 더해주고 fetchGetItems메서드를 호출하는 조건문 생성 ( 작동방법은 확실하지만 빠르게 스크롤을 내릴 경우 약간의 딜레이 발생되는 것처럼 보여짐 )
2. tableViewWillDisplay
 - cell이 다시 draw될 때 호출되는 건 맞지만, `tableView에서 이전에 설정한 state-based properties를 재정의 할 수 있다. (ex. backgroundColor ...)` 라고 하는 걸 봐서 주 용도가 infinite Scroll을 위한 것이 아니고, 우선시 되지 않아서 스크롤 시 보여주지 못할 가능성이 있다고 한다.

    > 참고 : [Apple Developer Document]("https://developer.apple.com/documentation/uikit/uitableviewdelegate/1614883-tableview")
